### PR TITLE
SPX is new name of Swish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -41,4 +41,4 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/Formula/spx.rb
+++ b/Formula/spx.rb
@@ -1,8 +1,8 @@
 class SPX < Formula
   desc "NPX for Swift"
   homepage "https://github.com/FullQueueDeveloper/SPX"
-  url "https://github.com/FullQueueDeveloper/SPX/archive/refs/tags/1.0.4.tar.gz"
-  sha256 "09f605e40e21e35bc3d6be90fe7dd578989b2ddd59845e0e85446f1de750d8c7"
+  url "https://github.com/FullQueueDeveloper/SPX/archive/refs/tags/1.1.0.tar.gz"
+  sha256 "83433261d3cf11c2215f84647c48c2ce3bd46d6828b6984b641c230cb1655661"
   # curl -sL $url | sha256sum
   license "MIT"
 

--- a/Formula/spx.rb
+++ b/Formula/spx.rb
@@ -1,7 +1,7 @@
-class Swish < Formula
-  desc "Swift script runner"
-  homepage "https://github.com/FullQueueDeveloper/Swish"
-  url "https://github.com/FullQueueDeveloper/Swish/archive/refs/tags/1.0.4.tar.gz"
+class SPX < Formula
+  desc "NPX for Swift"
+  homepage "https://github.com/FullQueueDeveloper/SPX"
+  url "https://github.com/FullQueueDeveloper/SPX/archive/refs/tags/1.0.4.tar.gz"
   sha256 "09f605e40e21e35bc3d6be90fe7dd578989b2ddd59845e0e85446f1de750d8c7"
   # curl -sL $url | sha256sum
   license "MIT"
@@ -16,6 +16,6 @@ class Swish < Formula
 
   test do
     # Test by showing the version
-    system "#{bin}/swish", "-v"
+    system "#{bin}/SPX", "-v"
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# FullQueueDeveloper Swish
+# FullQueueDeveloper Homebrew
 
-Brew formula for https://github.com/FullQueueDeveloper/Swish
+Brew formula for https://github.com/FullQueueDeveloper/
 
 ## How do I install these formulae?
 
-`brew install fullqueuedeveloper/swish/<formula>`
+`brew install fullqueuedeveloper/fullqueuedeveloper/<formula>`
 
-Or `brew tap fullqueuedeveloper/swish` and then `brew install <formula>`.
+Or `brew tap fullqueuedeveloper/fullqueuedeveloper` and then `brew install <formula>`.
+
+## Current formulae
+
+1. [SPX](https://github.com/FullQueueDeveloper/SPX) NPX for Swift
 
 ## Documentation
 


### PR DESCRIPTION
Full context available at https://fullqueuedeveloper.com/tech-notes/2023/04/02/spx-is-the-new-name-of-swish/